### PR TITLE
a few test improvements

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -20,7 +20,7 @@ module.exports = function install(callback) {
   let files = glob.sync(pattern).filter(function filter(filePath) {
     if (filePath.includes('node_modules'))
       return false
-    if (filePath.includes('vendor/bundle'))
+    if (filePath.includes(path.join('vendor', 'bundle')))
       return false
     return true
   })

--- a/src/update.js
+++ b/src/update.js
@@ -16,7 +16,7 @@ module.exports = function update(callback) {
   let files = glob.sync(pattern).filter(function filter(filePath) {
     if (filePath.includes('node_modules'))
       return false
-    if (filePath.includes('vendor/bundle'))
+    if (filePath.includes(path.join('vendor', 'bundle')))
       return false
     return true
   })


### PR DESCRIPTION
- dont hardcode path separators in install and update
- rely less on route names to infer runtime in integration tests, instead glob more
- move calls to `plan` to top of each test
- add a test ensuring subdependencies dont get hydrated

This closes #3 