### PR TITLE
Add 'hydrateShared' param to isolate single function hydration ops

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -15,24 +15,25 @@ let {inventory, updater} = require('@architect/utils')
  * - src/views
  */
 module.exports = function install(params={}, callback) {
-  let {basepath, copyShared=true, env, quiet, shell, timeout, verbose} = params
-  basepath = basepath || 'src'
+  let {
+    // Main params
+    basepath='src',
+    env,
+    shell,
+    timeout,
+    quiet,
+    verbose,
+    // Isolation / sandbox
+    copyShared=true,
+    hydrateShared=true
+  } = params
 
   /**
    * Find our dependency manifests
    */
   // eslint-disable-next-line
   let pattern = p => `${p}/**/@(package\.json|requirements\.txt|Gemfile)`
-  // Always hydrate src/shared + src/views
-  let sharedFiles = glob.sync(pattern(process.cwd())).filter(function filter(filePath) {
-    if (filePath.includes('node_modules') ||
-        filePath.includes('vendor/bundle'))
-      return false
-    if (filePath.includes('src/shared') ||
-        filePath.includes('src/views'))
-      return true
-  })
-  // Get everything else
+  // Get everything except shared
   let files = glob.sync(pattern(basepath)).filter(function filter(filePath) {
     if (filePath.includes('node_modules') ||
         filePath.includes('vendor/bundle') ||
@@ -41,7 +42,19 @@ module.exports = function install(params={}, callback) {
       return false
     return true
   })
-  files = files.concat(sharedFiles)
+  // Get src/shared + src/views
+  //   or disable if we're hydrating a single function in total isolation (e.g. sandbox startup)
+  if (hydrateShared) {
+    let sharedFiles = glob.sync(pattern(process.cwd())).filter(function filter(filePath) {
+      if (filePath.includes('node_modules') ||
+          filePath.includes('vendor/bundle'))
+        return false
+      if (filePath.includes('src/shared') ||
+          filePath.includes('src/views'))
+        return true
+    })
+    files = files.concat(sharedFiles)
+  }
 
   /**
    * Normalize paths


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [x] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [x] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [x] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
