### PR TITLE
Symlink directories whenever the filesystem supports it

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Architect Hydrate changelog
 
+### Changed
+
+- Added a `sandbox` flag, which causes files and directories to be symlinked
+  instead of copied, whenever the filesystem supports it. This improves
+  performance.
+
 ---
 
 ## [1.5.0] 2020-04-22

--- a/index.js
+++ b/index.js
@@ -19,19 +19,19 @@ module.exports = function hydrate(params={install:true}, callback) {
       }
     })
   }
-  let {verbose=false, basepath=''} = params
+  let {verbose=false, basepath='', sandbox=false} = params
   let tasks = []
   if (params.install)
     tasks.push(function install(callback) {
-      module.exports.install({verbose, basepath}, callback) // `install` includes `shared`
+      module.exports.install({verbose, basepath, sandbox}, callback) // `install` includes `shared`
     })
   else if (params.update)
     tasks.push(function update(callback) {
-      module.exports.update({verbose, basepath}, callback) // `update` includes `shared`
+      module.exports.update({verbose, basepath, sandbox}, callback) // `update` includes `shared`
     })
   else
     tasks.push(function shared(callback) {
-      module.exports.shared({}, callback)
+      module.exports.shared({sandbox}, callback)
     })
 
   series(tasks, function done(err) {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "glob": "~7.1.6",
     "rimraf": "~3.0.2",
     "run-series": "~1.1.8",
-    "strip-ansi": "~6.0.0"
+    "strip-ansi": "~6.0.0",
+    "symlink-or-copy": "~1.3.1"
   },
   "devDependencies": {
     "codecov": "^3.6.5",

--- a/src/shared/copy-arc.js
+++ b/src/shared/copy-arc.js
@@ -38,7 +38,7 @@ module.exports = function copyArc(params, callback) {
       else {
         series(paths.map(dest=> {
           return function copier(callback) {
-            copy(path.join(dest, 'shared'), callback)
+            copy(path.join(dest, 'shared'), params, callback)
           }
         }), _done)
       }
@@ -50,7 +50,7 @@ module.exports = function copyArc(params, callback) {
 /**
  * copy the current manifest into the destination dir
  */
-function copy(dest, callback) {
+function copy(dest, params, callback) {
   // path to destination
   let arcFileDest = path.join(dest, '.arc')
   // .arc in current working dir
@@ -63,10 +63,10 @@ function copy(dest, callback) {
   let arcJsonPath = path.join(process.cwd(), 'arc.json')
 
   if (fs.existsSync(arcFileSrc)) {
-    cp(arcFileSrc, arcFileDest, callback)
+    cp(arcFileSrc, arcFileDest, { sandbox: params.sandbox }, callback)
   }
   else if (fs.existsSync(arcAppDotArcPath)) {
-    cp(arcAppDotArcPath, arcFileDest, callback)
+    cp(arcAppDotArcPath, arcFileDest, { sandbox: params.sandbox }, callback)
   }
   else if (fs.existsSync(arcYamlPath)) {
     let raw = fs.readFileSync(arcYamlPath).toString()

--- a/src/shared/copy-shared.js
+++ b/src/shared/copy-shared.js
@@ -44,7 +44,9 @@ module.exports = function copyShared(params, callback) {
             let finalDest = path.join(dest, 'shared')
             rmrf(finalDest, {glob:false}, function(err) {
               if (err) callback(err)
-              else cp(shared, finalDest, callback)
+              else {
+                cp(shared, finalDest, { sandbox: params.sandbox }, callback)
+              }
             })
           }
         }), _done)

--- a/src/shared/copy-static-json.js
+++ b/src/shared/copy-static-json.js
@@ -46,7 +46,8 @@ module.exports = function copyStatic(params, callback) {
       else {
         series(paths.map(dest=> {
           return function copier(callback) {
-            cp(static, path.join(dest, 'shared', 'static.json'), callback)
+            cp(static, path.join(dest, 'shared', 'static.json'),
+              { sandbox: params.sandbox }, callback)
           }
         }), _done)
       }

--- a/src/shared/copy-views.js
+++ b/src/shared/copy-views.js
@@ -58,7 +58,7 @@ module.exports = function copyViews(params, callback) {
               let finalDest = path.join(dest, 'views')
               rmrf(finalDest, {glob:false}, function(err) {
                 if (err) callback(err)
-                else cp(views, finalDest, callback)
+                else cp(views, finalDest, { sandbox: params.sandbox }, callback)
               })
             }
             else {

--- a/src/shared/copy.js
+++ b/src/shared/copy.js
@@ -1,8 +1,27 @@
 let cp = require('cpr')
-// local helper to cleanup the cpr sig
-module.exports = function copy(source, destination, callback) {
-  cp(source, destination, {overwrite: true}, function done(err) {
-    if (err) callback(err)
-    else callback()
-  })
+let fs = require('fs')
+let path = require('path')
+let rimrafSync = require('rimraf').sync
+let mkdirp = require('mkdirp')
+let symlinkOrCopySync = require('symlink-or-copy').sync
+
+module.exports = function copy(source, destination, params, callback) {
+  if (params.sandbox) {
+    try {
+      if (fs.existsSync(destination)) {
+        rimrafSync(destination)
+      }
+      mkdirp.sync(path.dirname(destination))
+      symlinkOrCopySync(source, destination)
+    } catch (err) {
+      callback(err)
+      return
+    }
+    callback()
+  } else {
+    cp(source, destination, { overwrite: true }, function done(err) {
+      if (err) callback(err)
+      else callback()
+    })
+  }
 }

--- a/test/integration/integration-tests.js
+++ b/test/integration/integration-tests.js
@@ -312,6 +312,52 @@ test(`shared() should remove files in functions that do not exist in src/shared 
   })
 })
 
+if (process.platform !== 'win32') {
+  test(`shared() creates copies by default`, t => {
+    t.plan(1)
+    reset(function(err) {
+      if (err) t.fail(err)
+      else {
+        cp('_optional', 'src', {overwrite: true}, function done(err) {
+          if (err) t.fail(err)
+          else {
+            hydrate.shared({}, function done(err) {
+              if (err) t.fail(err)
+              else {
+                console.log(`noop log to help reset tap-spec lol`)
+                t.ok(!fs.lstatSync('src/http/get-index/node_modules/@architect/shared').isSymbolicLink(),
+                  'shared directory is a copy')
+              }
+            })
+          }
+        })
+      }
+    })
+  })
+
+  test(`shared() creates symlinks in sandbox mode`, t => {
+    t.plan(1)
+    reset(function(err) {
+      if (err) t.fail(err)
+      else {
+        cp('_optional', 'src', {overwrite: true}, function done(err) {
+          if (err) t.fail(err)
+          else {
+            hydrate.shared({ sandbox: true }, function done(err) {
+              if (err) t.fail(err)
+              else {
+                console.log(`noop log to help reset tap-spec lol`)
+                t.ok(fs.lstatSync('src/http/get-index/node_modules/@architect/shared').isSymbolicLink(),
+                  'shared directory is a symlink')
+              }
+            })
+          }
+        })
+      }
+    })
+  })
+}
+
 test(`install(undefined) hydrates all Functions', src/shared and src/views dependencies`, t=> {
   let count =
     pythonDependencies.length +


### PR DESCRIPTION
This addresses most of the performance issues in https://github.com/architect/architect/issues/908.

Please wait for CI to pass before merging. I didn't install the prerequisites so I couldn't run all of the tests locally.

The `copy` function can be turned into a synchronous function with this change, which will simplify code elsewhere as well by reducing callback waterfalls. Let me know if you're happy with this PR and I can add a commit to update the code.

(Before you ask: We benchmarked Node's filesystem operations extensively for the Broccoli build tool, and synchronous FS operations tend to match or outperform their async equivalents.)