### PR TITLE
Support for hydrating plugins

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [1.9.6] 2021-03-02
+
+### Added
+
+- Add support for Lambdas created via `@plugins` to be hydrated
+
+---
+
 ## [1.9.4 - 1.9.5] 2021-01-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/hydrate",
-  "version": "1.9.6-RC.0",
+  "version": "1.9.6-RC.1",
   "description": "Architect dependency hydrator and shared file manager",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/hydrate",
-  "version": "1.9.5",
+  "version": "1.9.6-RC.0",
   "description": "Architect dependency hydrator and shared file manager",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/architect/hydrate#readme",
   "dependencies": {
-    "@architect/inventory": "~1.2.1",
+    "@architect/inventory": "~1.3.0-RC.0",
     "@architect/parser": "~3.0.1",
     "@architect/utils": "~2.0.2",
     "acorn-loose": "~8.0.1",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   },
   "homepage": "https://github.com/architect/hydrate#readme",
   "dependencies": {
-    "@architect/inventory": "~1.3.0-RC.0",
+    "@architect/inventory": "~1.3.0-RC.1",
     "@architect/parser": "~3.0.1",
-    "@architect/utils": "~2.0.2",
+    "@architect/utils": "~2.0.5-RC.0",
     "acorn-loose": "~8.0.1",
     "chalk": "~4.1.0",
     "cpr": "~3.0.1",


### PR DESCRIPTION
This adds support for hydrating Lambdas created by the new `@plugins` pragma.

Relevant content:

- The Plugin Authoring docs PR is here: architect/arc.codes#324
- The original RFC is here: architect/architect#1062
- Dependent on `inventory` support for plugins (currently in RC): https://github.com/architect/inventory/pull/15