### PR TITLE
Fixes hydration of src/shared issue when multiple lambdas were aliased to the same source path

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [1.9.8] 2021-04-21
+
+### Fixed
+
+- Fixed issue where multiple lambdas aliased to the same source path would cause an error when hydrating `src/shared`; fixes [#1124](https://github.com/architect/architect/issues/1124)
+
+---
+
 ## [1.9.7] 2021-04-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/architect/hydrate#readme",
   "dependencies": {
-    "@architect/inventory": "~1.3.1",
+    "@architect/inventory": "~1.3.2",
     "@architect/parser": "~3.0.1",
     "@architect/utils": "~2.0.5",
     "acorn-loose": "~8.0.1",

--- a/src/shared/get-paths.js
+++ b/src/shared/get-paths.js
@@ -13,15 +13,16 @@ module.exports = function getPaths (inventory) {
     if (!existsSync(src)) return
     // Ok, here we go
     let lambdae = inv.lambdasBySrcDir[src]
+    // lambdasBySrcDir may be an object or array, depending on how many project lambdas are "aliased" to the same source path
+    // in either case, the underlying source dir will have a single config with a single runtime defined, so we only need to check the runtime once
     if (!Array.isArray(lambdae)) lambdae = [ lambdae ]
-    lambdae.forEach(lambda => {
-      let { config } = lambda
-      let nodeModules = join(src, 'node_modules', '@architect')
-      let vendorDir = join(src, 'vendor')
-      // Allow opting out of shared/views via config.arc @arc
-      let path = config.runtime.startsWith('nodejs') ? nodeModules : vendorDir
-      paths[src] = path
-    })
+    let lambda = lambdae[0]
+    let { config } = lambda
+    let nodeModules = join(src, 'node_modules', '@architect')
+    let vendorDir = join(src, 'vendor')
+    // Allow opting out of shared/views via config.arc @arc
+    let path = config.runtime.startsWith('nodejs') ? nodeModules : vendorDir
+    paths[src] = path
   })
 
   return paths

--- a/src/shared/get-paths.js
+++ b/src/shared/get-paths.js
@@ -12,12 +12,16 @@ module.exports = function getPaths (inventory) {
     // Don't create dirs for functions that don't already exist
     if (!existsSync(src)) return
     // Ok, here we go
-    let { config } = inv.lambdasBySrcDir[src]
-    let nodeModules = join(src, 'node_modules', '@architect')
-    let vendorDir = join(src, 'vendor')
-    // Allow opting out of shared/views via config.arc @arc
-    let path = config.runtime.startsWith('nodejs') ? nodeModules : vendorDir
-    paths[src] = path
+    let lambdae = inv.lambdasBySrcDir[src]
+    if (!Array.isArray(lambdae)) lambdae = [ lambdae ]
+    lambdae.forEach(lambda => {
+      let { config } = lambda
+      let nodeModules = join(src, 'node_modules', '@architect')
+      let vendorDir = join(src, 'vendor')
+      // Allow opting out of shared/views via config.arc @arc
+      let path = config.runtime.startsWith('nodejs') ? nodeModules : vendorDir
+      paths[src] = path
+    })
   })
 
   return paths

--- a/test/mocks/normal/_shared-custom/app.arc
+++ b/test/mocks/normal/_shared-custom/app.arc
@@ -16,6 +16,15 @@ any     /time-is-good/*
 /where
   method any
   src anywhere
+/multiples
+  method get
+  src src/http/multiples
+/api/v1/multiples
+  method get
+  src src/http/multiples
+/api/v2/multiples
+  method get
+  src src/http/multiples
 
 @events
 just-being-in-nature

--- a/test/mocks/normal/_shared-custom/app.arc-views
+++ b/test/mocks/normal/_shared-custom/app.arc-views
@@ -16,6 +16,15 @@ any     /time-is-good/*
 /where
   method any
   src anywhere
+/multiples
+  method get
+  src src/http/multiples
+/api/v1/multiples
+  method get
+  src src/http/multiples
+/api/v2/multiples
+  method get
+  src src/http/multiples
 
 @events
 just-being-in-nature

--- a/test/mocks/normal/app.arc
+++ b/test/mocks/normal/app.arc
@@ -14,6 +14,15 @@ any     /time-is-good/*
 /where
   method any
   src anywhere
+/multiples
+  method get
+  src src/http/multiples
+/api/v1/multiples
+  method get
+  src src/http/multiples
+/api/v2/multiples
+  method get
+  src src/http/multiples
 
 @events
 just-being-in-nature

--- a/test/mocks/normal/src/http/get-multiples/index.js
+++ b/test/mocks/normal/src/http/get-multiples/index.js
@@ -1,0 +1,7 @@
+exports.handler = async function http (req) {
+  console.log(req)
+  return {
+    type: 'text/html; charset=utf8',
+    body: '<h1>Hello world!</h1>'
+  }
+}

--- a/test/mocks/normal/src/http/get-multiples/package.json
+++ b/test/mocks/normal/src/http/get-multiples/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "hydrate-get-index",
+  "dependencies": {
+    "tiny-json-http": "^7.0.2"
+  }
+}

--- a/test/unit/src/shared/get-paths-tests.js
+++ b/test/unit/src/shared/get-paths-tests.js
@@ -1,0 +1,72 @@
+let test = require('tape')
+let { join } = require('path')
+let mockFs = require('mock-fs')
+let getPaths = require('../../../../src/shared/get-paths')
+let lambdaPath = join('app', 'src', 'http', 'get-items')
+let lambdaPathMockFs = lambdaPath.replace(/\\/g, '/') // mock-fs expects unix paths, even on windows :|
+
+test('inventory with a shared path to hydrate and a single node runtime lambda aliased to a single directory should return a path to node modules', t => {
+  t.plan(1)
+  mockFs({ [lambdaPathMockFs]: 'fake file contents' })
+  let inventory = {
+    inv: {
+      shared: {
+        shared: [ lambdaPath ]
+      },
+      lambdasBySrcDir: {
+        [lambdaPath]: {
+          name: 'get /items',
+          config: { runtime: 'nodejs12' }
+        }
+      }
+    }
+  }
+  let paths = getPaths(inventory)
+  t.equals(paths[lambdaPath], join(lambdaPath, 'node_modules', '@architect'), 'node runtime lambda returns node_modules path')
+  mockFs.restore()
+})
+
+test('inventory with a shared path to hydrate and a single non-node runtime lambda aliased to a single directory should return a path to vendor', t => {
+  t.plan(1)
+  let lambdaPath = join('app', 'src', 'http', 'get-items')
+  mockFs({ [lambdaPathMockFs]: 'fake file contents' })
+  let inventory = {
+    inv: {
+      shared: {
+        shared: [ lambdaPath ]
+      },
+      lambdasBySrcDir: {
+        [lambdaPath]: {
+          name: 'get /items',
+          config: { runtime: 'python3' }
+        }
+      }
+    }
+  }
+  let paths = getPaths(inventory)
+  t.equals(paths[lambdaPath], join(lambdaPath, 'vendor'), 'non-node runtime lambda returns vendor path')
+  mockFs.restore()
+})
+
+test('inventory with a shared path to hydrate and multiple node runtime lambdas aliased to a single directory should return a single path to node_modules', t => {
+  t.plan(1)
+  let lambdaPath = join('app', 'src', 'http', 'get-items')
+  mockFs({ [lambdaPathMockFs]: 'fake file contents' })
+  let inventory = {
+    inv: {
+      shared: {
+        shared: [ lambdaPath ]
+      },
+      lambdasBySrcDir: {
+        [lambdaPath]: [
+          { name: 'get /items', config: { runtime: 'nodejs12' } },
+          { name: 'get /api/v1/items', config: { runtime: 'nodejs12' } },
+          { name: 'get /api/v2/items', config: { runtime: 'nodejs12' } },
+        ]
+      }
+    }
+  }
+  let paths = getPaths(inventory)
+  t.equals(paths[lambdaPath], join(lambdaPath, 'node_modules', '@architect'), 'node runtime lambda returns node_modules path')
+  mockFs.restore()
+})

--- a/test/unit/src/shared/get-paths-tests.js
+++ b/test/unit/src/shared/get-paths-tests.js
@@ -1,6 +1,8 @@
 let test = require('tape')
 let { join } = require('path')
 let mockFs = require('mock-fs')
+// PUBLIC SERVICE ANNOUNCEMENT!
+// if youre going to edit these tests, always remember to mockFs.restore() BEFORE you assert with tape because https://github.com/tschaub/mock-fs/issues/201
 let getPaths = require('../../../../src/shared/get-paths')
 let lambdaPath = join('app', 'src', 'http', 'get-items')
 let lambdaPathMockFs = lambdaPath.replace(/\\/g, '/') // mock-fs expects unix paths, even on windows :|
@@ -22,8 +24,8 @@ test('inventory with a shared path to hydrate and a single node runtime lambda a
     }
   }
   let paths = getPaths(inventory)
-  t.equals(paths[lambdaPath], join(lambdaPath, 'node_modules', '@architect'), 'node runtime lambda returns node_modules path')
   mockFs.restore()
+  t.equals(paths[lambdaPath], join(lambdaPath, 'node_modules', '@architect'), 'node runtime lambda returns node_modules path')
 })
 
 test('inventory with a shared path to hydrate and a single non-node runtime lambda aliased to a single directory should return a path to vendor', t => {
@@ -44,8 +46,8 @@ test('inventory with a shared path to hydrate and a single non-node runtime lamb
     }
   }
   let paths = getPaths(inventory)
-  t.equals(paths[lambdaPath], join(lambdaPath, 'vendor'), 'non-node runtime lambda returns vendor path')
   mockFs.restore()
+  t.equals(paths[lambdaPath], join(lambdaPath, 'vendor'), 'non-node runtime lambda returns vendor path')
 })
 
 test('inventory with a shared path to hydrate and multiple node runtime lambdas aliased to a single directory should return a single path to node_modules', t => {
@@ -67,6 +69,6 @@ test('inventory with a shared path to hydrate and multiple node runtime lambdas 
     }
   }
   let paths = getPaths(inventory)
-  t.equals(paths[lambdaPath], join(lambdaPath, 'node_modules', '@architect'), 'node runtime lambda returns node_modules path')
   mockFs.restore()
+  t.equals(paths[lambdaPath], join(lambdaPath, 'node_modules', '@architect'), 'node runtime lambda returns node_modules path')
 })


### PR DESCRIPTION
This fixes https://github.com/architect/architect/issues/1124

Also relies on inventory 1.3.2-RC.0; should we cut a full release of inventory and bump it here before merging this?

Other additions:

- added unit tests to `src/shared/get-paths`
- expanded the mock app in use by integration tests for the multiple-lambdas-aliased-to-a-single-source-directory to cover this issue