### PR TITLE
Use Deno cache to hydrate the deno dependencies, so they're pre-cached

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,5 +1,5 @@
 let { pathToUnix } = require('@architect/utils')
-let isDep = file => file.includes('node_modules') || file.includes('vendor/bundle')
+let isDep = file => file.includes('node_modules') || file.includes('vendor/bundle') || file.includes('.deno_cache')
 let ignoreDeps = file => !isDep(pathToUnix(file))
 
 // Relativize by stripping leading relative path + `.`, `/`, `./`, `\`, `.\`


### PR DESCRIPTION
Hi 👋 

This PR would work alongside this one in Sandbox - [https://github.com/architect/sandbox/pull/585]( https://github.com/architect/sandbox/pull/585)

Together they enable hydration for deno runtime arc functions by setting the `DENO_DIR` to `vendor/.deno_cache` within each lambda and using `deno cache` to pre-cache the remote dependencies 

This massively speeds up individual invocation and stops issues where the lambda times out while Deno is caching the remote dependencies. 

Also could prove to be a handy pre-cache that could be used by the Deno lambda layer, moving the `.deno_cache` to `/tmp` to deploy pre-cached / hydrated Deno functions 

I've not worked up any tests yet, to feedback you could test with this basic repo - https://github.com/hicksy/deno-arc-example-login-flow - before the change the lambda will prob time out, with these PRs it'll hydrate during sandbox start and invoke promptly. 

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
