### PR TITLE
carefully filter require arguments

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- Filter out arguments to `require()` that aren't valid package name strings.
+- Fixed a crash related to `esquery` finding a variable declarator without an `init` field.
+
+---
+
 ## [1.10.1 - 1.10.2] 2021-06-20
 
 ### Fixed

--- a/test/mocks/deps/one.js
+++ b/test/mocks/deps/one.js
@@ -14,3 +14,16 @@ let a = require('@a/package')
 let b = require('@b/package/method')
 let c = require('c/specific/method')
 let d = require('d')
+
+// Minifiers may redefine variables to save space
+let missingInit
+missingInit = 'ignoredmodule'
+require(missingInit)
+
+// When minifiers redefine variables, the original might be an invalid module string
+let requiredThing = 'invalid module string'
+requiredThing = 'validmodule'
+require(requiredThing)
+
+// There may be a function called require that's not the real thing
+require(1234)

--- a/test/unit/src/actions/autoinstall/get-lambda-deps-tests.js
+++ b/test/unit/src/actions/autoinstall/get-lambda-deps-tests.js
@@ -12,7 +12,7 @@ test('Set up env', t => {
 })
 
 test(`Walk a folder's deps`, t => {
-  t.plan(4)
+  t.plan(7)
   let stdout = process.stdout.write
   let data = ''
   process.stdout.write = write => {
@@ -30,4 +30,7 @@ test(`Walk a folder's deps`, t => {
   t.equal(files.length, 6, 'Walked 6 js files')
 
   t.match(data, /'something'/, 'Warned about dynamic require')
+  t.match(data, /'missingInit'/, 'Warned about reassigned require argument string')
+  t.match(data, /'invalid module string'/, 'Warned about invalid module string')
+  t.match(data, /'1234'/, 'Warned about non-string require argument')
 })


### PR DESCRIPTION
I've tried to hydrate some code I ran through esbuild (to ease typescript compilation), and I noticed some issues that came up since it minifies code.

Most of them were related to esbuild (like other minifiers) reusing variables, as illustrated in the test mock I've changed.

I also fixed a crash which occurred when esquery returned a VariableDeclarator without an initializer.

Nice project, keep it up, and hope this helps! <3

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
