### PR TITLE
Fix `arc.static()` not working if using `@static fingerprint true` but don't have `src/shared`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [1.10.1] 2021-06-20
+
+### Fixed
+
+- Fixed issue where `@architect/functions` `arc.static()` method may not work if using `@static fingerprint true`, but aren't using `src/shared` or `@static src some-dir`
+
+---
+
 ## [1.10.0] 2021-06-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/architect/hydrate#readme",
   "dependencies": {
-    "@architect/inventory": "~1.4.0",
+    "@architect/inventory": "~1.4.2-RC.0",
     "@architect/parser": "~3.0.1",
     "@architect/utils": "~2.1.2",
     "acorn-loose": "~8.1.0",

--- a/src/shared/copy-arc.js
+++ b/src/shared/copy-arc.js
@@ -23,7 +23,7 @@ module.exports = function copyArc (params, paths, callback) {
     let done = `Hydrated app with Architect manifest`
     let start = update.start(`Hydrating app with Architect manifest`)
 
-    let destinations = Object.entries(paths).map(p => p[1])
+    let destinations = Object.entries(paths.all).map(p => p[1])
     series(destinations.map(dest => {
       return function copier (callback) {
         copy(join(dest, 'shared'), params, callback)

--- a/src/shared/copy-shared.js
+++ b/src/shared/copy-shared.js
@@ -27,8 +27,8 @@ module.exports = function copyShared (params, paths, callback) {
 
     series(shared.map(share => {
       return function copier (callback) {
-        if (paths[share]) {
-          let finalDest = join(paths[share], 'shared')
+        if (paths.shared[share]) {
+          let finalDest = join(paths.shared[share], 'shared')
           cp(src, finalDest, params, callback)
         }
         else callback()

--- a/src/shared/copy-static-json.js
+++ b/src/shared/copy-static-json.js
@@ -26,7 +26,7 @@ module.exports = function copyStatic (params, paths, callback) {
     let done = `Hydrated app with static.json`
     let start = update.start(`Hydrating app with static.json`)
 
-    let destinations = Object.entries(paths).map(p => p[1])
+    let destinations = Object.entries(paths.all).map(p => p[1])
     series(destinations.map(dest => {
       return function copier (callback) {
         cp(static, join(dest, 'shared', 'static.json'), params, callback)

--- a/src/shared/copy-views.js
+++ b/src/shared/copy-views.js
@@ -27,8 +27,8 @@ module.exports = function copyViews (params, paths, callback) {
 
     series(views.map(view => {
       return function copier (callback) {
-        if (paths[view]) {
-          let finalDest = join(paths[view], 'views')
+        if (paths.views[view]) {
+          let finalDest = join(paths.views[view], 'views')
           cp(src, finalDest, params, callback)
         }
         else callback()


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
