### PR TITLE
Fix detection of CJS/ESM when strings `import` and `require` are present in the AST

### DIFF
--- a/src/actions/autoinstall/find-lambda-deps.js
+++ b/src/actions/autoinstall/find-lambda-deps.js
@@ -9,8 +9,8 @@ module.exports = function findLambdaDeps ({ dir, file, update }) {
   let opts = { ecmaVersion: 'latest', onToken: tokens }
   // Loose is a little gentler on userland code; we aren't here to judge code quality!
   let ast = loose.parse(contents, opts)
-  let hasImport = tokens.some(({ value }) => value === 'import')
-  let hasRequire = tokens.some(({ value }) => value === 'require')
+  let hasImport = tokens.some(({ value, type }) => value === 'import' && type?.label !== 'string')
+  let hasRequire = tokens.some(({ value, type }) => value === 'require' && type?.label !== 'string')
 
   // Exit early if module doesn't require any dependencies
   if (!hasRequire && !hasImport) return

--- a/test/mocks/deps-cjs/subfolder/subsubfolder/strings.js
+++ b/test/mocks/deps-cjs/subfolder/subsubfolder/strings.js
@@ -1,0 +1,4 @@
+let strings = [
+  'require',
+  'import',
+]

--- a/test/mocks/deps-esm/subfolder/subsubfolder/strings.js
+++ b/test/mocks/deps-esm/subfolder/subsubfolder/strings.js
@@ -1,0 +1,4 @@
+let strings = [
+  'require',
+  'import',
+]

--- a/test/mocks/deps-mixed/bueno.js
+++ b/test/mocks/deps-mixed/bueno.js
@@ -1,3 +1,7 @@
+let strings = [
+  'require',
+  'import',
+]
 function hello (friend) {
   return `Hello, ${friend}!`
 }

--- a/test/unit/src/actions/autoinstall/get-lambda-deps-tests.js
+++ b/test/unit/src/actions/autoinstall/get-lambda-deps-tests.js
@@ -5,6 +5,7 @@ let getLambdaDeps = require(sut)
 let mock = join(process.cwd(), 'test', 'mocks')
 let { updater } = require('@architect/utils')
 let update = updater('Hydrate')
+let jsFiles = 8
 
 test('Set up env', t => {
   t.plan(1)
@@ -25,7 +26,7 @@ test(`Walk CommonJS deps`, t => {
 
   t.deepEqual(deps.sort(), correct, `Got correct deps`)
   t.notOk(failures.length, 'Got no failures')
-  t.equal(files.length, 7, 'Walked 7 js files')
+  t.equal(files.length, jsFiles, `Walked ${jsFiles} js files`)
   t.match(data, /'something'/, 'Warned about dynamic require')
 })
 
@@ -43,7 +44,7 @@ test(`Walk ESM deps`, t => {
 
   t.deepEqual(deps.sort(), correct, `Got correct deps`)
   t.notOk(failures.length, 'Got no failures')
-  t.equal(files.length, 7, 'Walked 7 js files')
+  t.equal(files.length, jsFiles, `Walked ${jsFiles} js files`)
   t.match(data, /'something'/, 'Warned about dynamic require')
 })
 


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
