### PR TITLE
Fix obscure case where copying `static.json` may fail when a shared folder is removed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [3.0.6] 2022-08-20
+
+### Fixed
+
+- Fix obscure case where copying `static.json` may fail when a shared folder is removed from the project; fixes #1367
+
+---
+
 ## [3.0.5] 2022-08-11
 
 ### Fixed

--- a/src/shared/index.js
+++ b/src/shared/index.js
@@ -1,5 +1,6 @@
 let series = require('run-series')
 let getPaths = require('./get-paths')
+let resetShared = require('./reset')
 let copyShared = require('./copy-shared')
 let copyViews = require('./copy-views')
 let copyStaticJSON = require('./copy-static-json')
@@ -48,6 +49,9 @@ module.exports = function shared (params = {}, callback) {
       }
       paths = getPaths(inventory)
       callback()
+    },
+    function (callback) {
+      resetShared(paths, callback)
     },
     function (callback) {
       copyShared(params, paths, callback)

--- a/src/shared/reset.js
+++ b/src/shared/reset.js
@@ -1,0 +1,14 @@
+let { destroyPath } = require('../lib')
+
+/**
+ * Reset all node_modules/@architect shared folders
+ */
+module.exports = function resetShared (paths, callback) {
+  let destroy = Object.values(paths.all).filter(p => p.includes('@architect'))
+  if (destroy.length) {
+    for (let path of destroy) {
+      destroyPath(path)
+    }
+  }
+  callback()
+}


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
