### PR TITLE
Fix issue where autoinstall would fail to parse `require` or `import` within for/of statements; fixes #1370

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ---
 
-## [3.1.0 - 3.1.1] 2022-08-20
+## [3.1.0 - 3.1.2] 2022-08-20
 
 ### Added
 
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Fixed issue where `hydrate.shared()` erroneously destroys the `@architect/functions` module; thanks @idy!
+- Fixed issue where autoinstall would fail to parse `require` or `import` within for/of statements; fixes #1370
 
 ---
 

--- a/src/actions/autoinstall/find-lambda-deps.js
+++ b/src/actions/autoinstall/find-lambda-deps.js
@@ -27,7 +27,8 @@ module.exports = function findLambdaDeps ({ dir, file, update }) {
   function getIdentifier (id) {
     let ids = esquery.query(ast, `[id.name='${id}']`) || []
     ids.forEach(r => {
-      if (r.init.value) called.push(r.init.value)
+      // Note: r.init may be null in certain cases (such as variable declarations in for/of statements)
+      if (r.init?.value) called.push(r.init.value)
       else update.warn(`Dynamic ${isESM ? 'imports' : 'requires'} are not supported, dependency may not be installed: ${dir} imports '${id}'`)
     })
   }

--- a/test/mocks/deps-cjs/subfolder/subsubfolder/six.js
+++ b/test/mocks/deps-cjs/subfolder/subsubfolder/six.js
@@ -1,5 +1,9 @@
 let something = process.env.SOMETHING
 require(something)
 
+for (let item of [ 1, 2, 3 ]) {
+  require(item)
+}
+
 // Also require 'c' to test de-duping
 require('c')

--- a/test/mocks/deps-esm/subfolder/subsubfolder/six.js
+++ b/test/mocks/deps-esm/subfolder/subsubfolder/six.js
@@ -1,5 +1,9 @@
 let something = process.env.SOMETHING
 await import(something)
 
+for (let item of [ 1, 2, 3 ]) {
+  await import(item)
+}
+
 // Also import 'c' to test de-duping
 await import('c')


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
