### PR TITLE
Changed `hydrate.copy` API to copy files into all Lambdas, not just those with shared code enabled

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,19 @@
 
 ---
 
+## [3.1.5] 2022-11-15
+
+### Changed
+
+- Changed `hydrate.copy` API to copy files into all Lambdas, not just those with shared code enabled
+
+
+### Fixed
+
+- Fixed issue where `hydrate.copy` plugins breaking on projects that disabled or aren't using shared code; thanks @tbeseda!
+
+---
+
 ## [3.1.4] 2022-10-07
 
 ### Fixed

--- a/src/shared/copy-plugins.js
+++ b/src/shared/copy-plugins.js
@@ -36,13 +36,13 @@ module.exports = function runCopyPlugins (params, paths, callback) {
               if (target && isAbsolute(target)) return rej(ReferenceError(`'target' path '${target}' cannot be absolute`))
 
               // Sure what's one more nested sequence of ops?
-              series(lambdaSrcDirs.map(lambda => {
+              series(lambdaSrcDirs.map(dir => {
                 return function copier (callback) {
-                  let { config, src } = lambdasBySrcDir[lambda]
-                  let isNode = config.runtime.startsWith('nodejs')
+                  let lambda = lambdasBySrcDir[dir]
+                  let isNode = lambda.config.runtime.startsWith('nodejs')
                   let filename = target || basename(source)
-                  let nodeModules = join(src, 'node_modules', filename)
-                  let vendorDir = join(src, 'vendor', filename)
+                  let nodeModules = join(lambda.src, 'node_modules', filename)
+                  let vendorDir = join(lambda.src, 'vendor', filename)
                   let dest = isNode ? nodeModules : vendorDir
                   cp(src, dest, params, callback)
                 }

--- a/test/integration/_shared.js
+++ b/test/integration/_shared.js
@@ -118,6 +118,8 @@ let pluginArtifacts = []
   .concat(pythonFunctions.map(p => threePluginFiles(p, 'vendor')))
   .concat(rubyFunctions.map(p => threePluginFiles(p, 'vendor')))
   .concat(nodeFunctions.map(p => threePluginFiles(p, 'node_modules')))
+  // hydrate.copy copies to all functions, even with shared disabled
+  .concat([ join('src', 'events', 'silence') ].map(p => threePluginFiles(p, 'node_modules')))
   .concat(arcCustomPath.map(p => threePluginFiles(p, 'node_modules')))
   .concat(arcAutoinstall.map(p => threePluginFiles(p, 'node_modules')))
   .flat()

--- a/test/integration/default/shared-tests.js
+++ b/test/integration/default/shared-tests.js
@@ -130,7 +130,8 @@ test(`[Shared file copying with plugins (default paths)] shared() copies shared 
               pluginArtifacts.forEach(path => {
                 t.ok(existsSync(path), `Found plugin file in ${path}`)
               })
-              checkFolderCreation(t)
+              let normallyShouldNotBePresent = join('src', 'events', 'silence', 'node_modules')
+              t.ok(existsSync(normallyShouldNotBePresent), 'Silence event folder created just this once!')
             }
           })
         }

--- a/test/integration/symlink/shared-tests.js
+++ b/test/integration/symlink/shared-tests.js
@@ -134,7 +134,8 @@ test(`[Shared file symlinking with plugins (default paths)] shared() copies shar
               pluginArtifacts.forEach(path => {
                 t.ok(existsSync(path), `Found plugin file in ${path}`)
               })
-              checkFolderCreation(t)
+              let normallyShouldNotBePresent = join('src', 'events', 'silence', 'node_modules')
+              t.ok(existsSync(normallyShouldNotBePresent), 'Silence event folder created just this once!')
             }
           })
         }


### PR DESCRIPTION
Fixed issue where `hydrate.copy` plugins breaking on projects that disabled or aren't using shared code

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
