### PR TITLE
Fix `hydrate.copy` API bug where Lambda build dir is not used

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [3.1.7] 2022-12-05
+
+### Fixed
+
+- Fixed `hydrate.copy` API bug where Lambda build dir is not used
+
+---
+
 ## [3.1.6] 2022-11-18
 
 ### Added

--- a/src/shared/copy-plugins.js
+++ b/src/shared/copy-plugins.js
@@ -41,8 +41,9 @@ module.exports = function runCopyPlugins (params, paths, callback) {
                   let lambda = lambdasBySrcDir[dir]
                   let isNode = lambda.config.runtime.startsWith('nodejs')
                   let filename = target || basename(source)
-                  let nodeModules = join(lambda.src, 'node_modules', filename)
-                  let vendorDir = join(lambda.src, 'vendor', filename)
+                  let base = lambda.build || lambda.src
+                  let nodeModules = join(base, 'node_modules', filename)
+                  let vendorDir = join(base, 'vendor', filename)
                   let dest = isNode ? nodeModules : vendorDir
                   cp(src, dest, params, callback)
                 }


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
