### PR TITLE
Fix `hydrate.copy` API bug where files are copied to `vendor`, not `node_modules`, for `typescript` Lambdas

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [3.1.8] 2022-12-06
+
+### Fixed
+
+- Fixed `hydrate.copy` API bug where files are copied to `vendor`, not `node_modules`, for `typescript` Lambdas
+
+---
+
 ## [3.1.7] 2022-12-05
 
 ### Fixed

--- a/src/shared/copy-plugins.js
+++ b/src/shared/copy-plugins.js
@@ -39,7 +39,8 @@ module.exports = function runCopyPlugins (params, paths, callback) {
               series(lambdaSrcDirs.map(dir => {
                 return function copier (callback) {
                   let lambda = lambdasBySrcDir[dir]
-                  let isNode = lambda.config.runtime.startsWith('nodejs')
+                  let isNode = lambda.config?.runtimeConfig?.baseRuntime?.startsWith('nodejs') ||
+                               lambda.config.runtime.startsWith('nodejs')
                   let filename = target || basename(source)
                   let base = lambda.build || lambda.src
                   let nodeModules = join(base, 'node_modules', filename)


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
