### PR TITLE
feat(pnpm): adding support for PNPM and manually specifing a pkg manager

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -34,6 +34,7 @@ async function main (opts = {}) {
     inventory,
     autoinstall:  args.autoinstall,
     verbose:      args.verbose,
+    pkgManager:   args.pkgManager?.trim()
   }
 
   if (args.shared) {


### PR DESCRIPTION
This change adds support for PNPM package manger as well as manually specifying which package manger to use in the case where the user is using a monorepo and the package manager can not be inferred. 

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
