### PR TITLE
bugfix: copy-plugin: src should be source when absolute

### DIFF
--- a/src/shared/copy-plugins.js
+++ b/src/shared/copy-plugins.js
@@ -30,7 +30,7 @@ module.exports = function runCopyPlugins (params, paths, callback) {
               if (!source) return rej(ReferenceError(`must return 'source' path`))
 
               // Make sure we normalize source paths to absolute
-              let src = isAbsolute(source) ? isAbsolute : join(cwd, source)
+              let src = isAbsolute(source) ? source : join(cwd, source)
               if (!existsSync(src)) return rej(ReferenceError(`'source' path '${source}' not found in project`))
 
               if (target && isAbsolute(target)) return rej(ReferenceError(`'target' path '${target}' cannot be absolute`))


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
