### PR TITLE
Fix for issue with single ignored dependency

### DIFF
--- a/src/actions/autoinstall/node/get-lambda-deps.js
+++ b/src/actions/autoinstall/node/get-lambda-deps.js
@@ -35,7 +35,9 @@ module.exports = function getDirDeps ({ dir, update, inventory, ignored }) {
   // However, due to SDK version differences between older vs. newer Node.js Lambda containers, that may not actually necessarily be the case, so flag them
   let awsSdkV2 = deps.some(d => d === 'aws-sdk')
   let awsSdkV3 = deps.some(d => d.startsWith('@aws-sdk'))
-  deps = deps.filter(d => d !== 'aws-sdk' && !d.startsWith('@aws-sdk') && !ignored?.includes(d))
+  deps = deps.filter(d => d !== 'aws-sdk'
+    && !d.startsWith('@aws-sdk')
+    && (Array.isArray(ignored) ? !ignored.includes(d) : d !== ignored))
 
   return { deps, failures, files, awsSdkV2, awsSdkV3 }
 }


### PR DESCRIPTION
Current logic for ignored dependencies only worked if two or more dependencies are marked as ignored, as it assumes the `ignored` property is an array.

This PR adds an additional check that the value is an array, and only then runs it via `.includes()`, else performs a direct comparison which works with both a single ignored dependency string as well as `undefined`.