### PR TITLE
fix: pnpm sym links with pnpm --node-linker=hoisted

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 ### Fixed
 
 - pnpm install and update commands now use `--config.node-linker=hoisted` to produce a flat `node_modules` layout compatible with AWS Lambda (which does not support symlinks)
+- pnpm commands now pass `CI=true` in the environment to prevent interactive prompts in non-TTY contexts
 
 ---
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,14 @@
 # Architect Hydrate changelog
 ---
 
+## [6.0.1]
+
+### Fixed
+
+- pnpm install and update commands now use `--config.node-linker=hoisted` to produce a flat `node_modules` layout compatible with AWS Lambda (which does not support symlinks)
+
+---
+
 ## [6.0.0]
 
 ### Breaking Changes

--- a/src/actions/install-update.js
+++ b/src/actions/install-update.js
@@ -97,7 +97,7 @@ module.exports = function hydrator (params, callback) {
             localPnpm = true
           }
           catch { /* noop */ }
-          let cmd = localPnpm ? `npx pnpm i ${prodFlag}` : `pnpm i ${prodFlag}`
+          let cmd = localPnpm ? `npx pnpm --node-linker=hoisted i ${prodFlag}` : `pnpm --node-linker=hoisted i ${prodFlag}`
           exec(cmd, options, callback)
         }
         else if (isYarn) {
@@ -120,7 +120,7 @@ module.exports = function hydrator (params, callback) {
       else if (isJs && !installing) {
         if (isPnpm) {
           let localPnpm = exists(join(cwd, 'node_modules', 'pnpm'))
-          let cmd = localPnpm ? 'npx pnpm update' : 'pnpm update'
+          let cmd = localPnpm ? 'npx pnpm --node-linker=hoisted update' : 'pnpm --node-linker=hoisted update'
           exec(cmd, options, callback)
         }
         else if (isYarn) {
@@ -146,8 +146,8 @@ module.exports = function hydrator (params, callback) {
           let arch = lambda.config.architecture === 'arm64' ? 'manylinux2014_aarch64' : 'manylinux2014_x86_64'
           let ver = lambda.config.runtime.split('python')[1]
           flags = '--only-binary=:all: ' +
-                  `--platform=${arch} ` +
-                  `--python-version ${ver} `
+            `--platform=${arch} ` +
+            `--python-version ${ver} `
           // Reset flags if installing from Sandbox
           if (local) flags = ''
 

--- a/src/actions/install-update.js
+++ b/src/actions/install-update.js
@@ -97,7 +97,7 @@ module.exports = function hydrator (params, callback) {
             localPnpm = true
           }
           catch { /* noop */ }
-          let cmd = localPnpm ? `npx pnpm --node-linker=hoisted i ${prodFlag}` : `pnpm --node-linker=hoisted i ${prodFlag}`
+          let cmd = localPnpm ? `npx pnpm --config.node-linker=hoisted i ${prodFlag}` : `pnpm --config.node-linker=hoisted i ${prodFlag}`
           exec(cmd, options, callback)
         }
         else if (isYarn) {
@@ -120,7 +120,7 @@ module.exports = function hydrator (params, callback) {
       else if (isJs && !installing) {
         if (isPnpm) {
           let localPnpm = exists(join(cwd, 'node_modules', 'pnpm'))
-          let cmd = localPnpm ? 'npx pnpm --node-linker=hoisted update' : 'pnpm --node-linker=hoisted update'
+          let cmd = localPnpm ? 'npx pnpm --config.node-linker=hoisted update' : 'pnpm --config.node-linker=hoisted update'
           exec(cmd, options, callback)
         }
         else if (isYarn) {

--- a/src/actions/install-update.js
+++ b/src/actions/install-update.js
@@ -98,7 +98,8 @@ module.exports = function hydrator (params, callback) {
           }
           catch { /* noop */ }
           let cmd = localPnpm ? `npx pnpm --config.node-linker=hoisted i ${prodFlag}` : `pnpm --config.node-linker=hoisted i ${prodFlag}`
-          exec(cmd, options, callback)
+          let pnpmOptions = { ...options, env: { ...(options.env || process.env), CI: 'true' } }
+          exec(cmd, pnpmOptions, callback)
         }
         else if (isYarn) {
           let localYarn
@@ -121,7 +122,8 @@ module.exports = function hydrator (params, callback) {
         if (isPnpm) {
           let localPnpm = exists(join(cwd, 'node_modules', 'pnpm'))
           let cmd = localPnpm ? 'npx pnpm --config.node-linker=hoisted update' : 'pnpm --config.node-linker=hoisted update'
-          exec(cmd, options, callback)
+          let pnpmOptions = { ...options, env: { ...(options.env || process.env), CI: 'true' } }
+          exec(cmd, pnpmOptions, callback)
         }
         else if (isYarn) {
           let localYarn = exists(join(cwd, 'node_modules', 'yarn'))


### PR DESCRIPTION
This fixes the pnpm issue of sym linked sub dependencies (https://github.com/architect/architect/issues/1522). The patch should also be added to version 5 since this is still used widely. 
